### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ You will be using pcs to configure your cluster.  To start and enable the pcsd d
 sudo systemctl start pcsd.service
 sudo systemctl enable pcsd.service
 ```
+To have pacemaker and corosync start on reboot, run the following on both nodes:
+```bash
+sudo systemctl enable corosync
+sudo systemctl enable pacemaker
+```
 
 The cluster software creates a user hacluster which will be used to configure the cluster. The hacluster user will be used by the cluster to perform cluster tasks like syncing the configuration and starting and stopping services on cluster nodes. To get started, the password for hacluster needs to be set on both the nodes and has to be same. To set the password for the hacluster user run the following commands on both the nodes:
 ```bash


### PR DESCRIPTION
These steps works on Amazon Linux 2 as well, however I had to enable both corosync and pacemaker services for them to startup on reboot. I can only assume it's the same for CentOS.

*Description of changes:*
Additional steps to ensure corosync and pacemaker startup on reboot.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
